### PR TITLE
[ADD] Color Asset 추가와 Font Extension을 구현했습니다.

### DIFF
--- a/KKewo-iOS/KKewo-iOS/Assets.xcassets/gray00.colorset/Contents.json
+++ b/KKewo-iOS/KKewo-iOS/Assets.xcassets/gray00.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF2",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF2",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/KKewo-iOS/KKewo-iOS/Assets.xcassets/gray01.colorset/Contents.json
+++ b/KKewo-iOS/KKewo-iOS/Assets.xcassets/gray01.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xE9",
+          "red" : "0xE9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xE9",
+          "red" : "0xE9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/KKewo-iOS/KKewo-iOS/Assets.xcassets/gray02.colorset/Contents.json
+++ b/KKewo-iOS/KKewo-iOS/Assets.xcassets/gray02.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA6",
+          "green" : "0xA6",
+          "red" : "0xA6"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA6",
+          "green" : "0xA6",
+          "red" : "0xA6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/KKewo-iOS/KKewo-iOS/Assets.xcassets/gray03.colorset/Contents.json
+++ b/KKewo-iOS/KKewo-iOS/Assets.xcassets/gray03.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x80",
+          "green" : "0x80",
+          "red" : "0x80"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x80",
+          "green" : "0x80",
+          "red" : "0x80"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/KKewo-iOS/KKewo-iOS/Assets.xcassets/gray04.colorset/Contents.json
+++ b/KKewo-iOS/KKewo-iOS/Assets.xcassets/gray04.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x40",
+          "green" : "0x40",
+          "red" : "0x40"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x40",
+          "green" : "0x40",
+          "red" : "0x40"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/KKewo-iOS/KKewo-iOS/Assets.xcassets/orange00.colorset/Contents.json
+++ b/KKewo-iOS/KKewo-iOS/Assets.xcassets/orange00.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE5",
+          "green" : "0xF4",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE5",
+          "green" : "0xF4",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/KKewo-iOS/KKewo-iOS/Assets.xcassets/orange01.colorset/Contents.json
+++ b/KKewo-iOS/KKewo-iOS/Assets.xcassets/orange01.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x95",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x95",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/KKewo-iOS/KKewo-iOS/Resources/Font/Font+.swift
+++ b/KKewo-iOS/KKewo-iOS/Resources/Font/Font+.swift
@@ -1,0 +1,34 @@
+//
+//  Font+.swift
+//  KKewo-iOS
+//
+//  Created by 이승진 on 5/9/25.
+//
+
+import SwiftUI
+
+extension Font {
+    enum Pretendard {
+        case bold
+        case semibold
+        case medium
+        case regular
+        
+        var value: String {
+            switch self {
+            case .bold:
+                return "Pretendard-Bold"
+            case .semibold:
+                return "Pretendard-SemiBold"
+            case .medium:
+                return "Pretendard-Medium"
+            case .regular:
+                return "Pretendard-Medium"
+            }
+        }
+    }
+    
+    static func pretendard(type: Pretendard, size: CGFloat) -> Font {
+        return .custom(type.value, size: size)
+    }
+}


### PR DESCRIPTION
### Issue Number
- #1 

### 새로운 기능
- Font Extension 구현
- Color Asset 추가
```swift
Text("폰트 및 컬러")
    .font(.pretendard(type: .bold, size: 30))
    .foregroundStyle(.orange01)
```