### PR TITLE
[FEAT] OnboardingView의 UI를 구현했습니다.

### DIFF
--- a/KKewo-iOS/KKewo-iOS/Feature/Onboarding/OnboardingAlarmIntroView.swift
+++ b/KKewo-iOS/KKewo-iOS/Feature/Onboarding/OnboardingAlarmIntroView.swift
@@ -1,0 +1,37 @@
+//
+//  OnboardingAlarmIntroView.swift
+//  KKewo-iOS
+//
+//  Created by 여성일 on 5/22/25.
+//
+
+import SwiftUI
+
+struct OnboardingAlarmIntroView: View {
+    let onNextButtonTapped: () -> Void
+    
+    var body: some View {
+        VStack {
+            Text("멘토들의 알람벨을 고를 수 있어요!")
+                .font(.pretendard(type: .semibold, size: 16))
+                .foregroundStyle(.gray03)
+            
+            Rectangle()
+                .padding(.top, 74)
+                .padding(.horizontal, 63)
+            
+            Spacer()
+            
+            CustomBorderButton(action: onNextButtonTapped,
+                               title: "다음",
+                               titleColor: .orange01,
+                               backgroundColor: .orange00
+            )
+            .padding(.horizontal, 24)
+        }
+    }
+}
+
+#Preview {
+    OnboardingAlarmIntroView(onNextButtonTapped: { })
+}

--- a/KKewo-iOS/KKewo-iOS/Feature/Onboarding/OnboardingView.swift
+++ b/KKewo-iOS/KKewo-iOS/Feature/Onboarding/OnboardingView.swift
@@ -1,0 +1,67 @@
+//
+//  OnboardingView.swift
+//  KKewo-iOS
+//
+//  Created by 여성일 on 5/22/25.
+//
+
+import SwiftUI
+
+struct OnboardingView: View {
+    @State private var currentPage: Int = 0
+    
+    private let totalPage = 2
+    
+    var body: some View {
+        VStack {
+            HStack(spacing: 6) {
+                ForEach(0..<totalPage, id: \.self) { index in
+                    Circle()
+                        .frame(width: currentPage == index ? 12 : 10,
+                               height: currentPage == index ? 12 : 10)
+                        .foregroundStyle(currentPage == index ? .orange01 : .gray01)
+                        .animation(.easeInOut(duration: 0.3), value: currentPage)
+                }
+            }
+            
+            VStack(spacing: 0) {
+                Text("혼자 일어나기 힘든 러너들,")
+                    .font(.pretendard(type: .bold, size: 20))
+                    .foregroundStyle(.gray05)
+                
+                Text("멘토들이 깨워드릴게요!")
+                    .font(.pretendard(type: .bold, size: 28))
+                    .foregroundStyle(.gray05)
+            }
+            .padding(.top, 32)
+            
+            TabView(selection: $currentPage) {
+                OnboardingAlarmIntroView(onNextButtonTapped: handleNextAction)
+                    .tag(0)
+                
+                OnboardingVoiceIntroView(onRecommendButtonTapped: handleRecommendAction)
+                    .tag(1)
+            }
+            .padding(.top, 72)
+            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+        }
+        .padding(.vertical, 24)
+    }
+}
+
+private extension OnboardingView {
+    func handleNextAction() {
+        withAnimation(.easeInOut) {
+            currentPage = 1
+        }
+    }
+    
+    func handleRecommendAction() {
+        
+    }
+}
+
+#Preview {
+    OnboardingView()
+}
+

--- a/KKewo-iOS/KKewo-iOS/Feature/Onboarding/OnboardingVoiceIntroView.swift
+++ b/KKewo-iOS/KKewo-iOS/Feature/Onboarding/OnboardingVoiceIntroView.swift
@@ -1,0 +1,32 @@
+//
+//  OnboardingVoiceIntroView.swift
+//  KKewo-iOS
+//
+//  Created by 여성일 on 5/22/25.
+//
+
+import SwiftUI
+
+struct OnboardingVoiceIntroView: View {
+    let onRecommendButtonTapped: () -> Void
+    
+    var body: some View {
+        VStack {
+            Text("멘토들의 목소리로 하루를 시작해볼까요?")
+                .font(.pretendard(type: .semibold, size: 16))
+                .foregroundStyle(.gray03)
+            
+            Rectangle()
+                .padding(.top, 74)
+            
+            Spacer()
+            
+            CustomBorderButton(action: onRecommendButtonTapped, title: "알람벨 추천받기", titleColor: .white, backgroundColor: .orange01)
+                .padding(.horizontal, 24)
+        }
+    }
+}
+
+#Preview {
+    OnboardingVoiceIntroView(onRecommendButtonTapped: { })
+}


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
1. OnboardingView
- OnboardingView의 UI를 구현했습니다.

2. OnboardingAlarmIntroView
- 탭뷰 페이징에 사용 될 첫번째 페이지입니다.
- OnboardingAlarmIntroView의 UI를 구현했습니다.
- 다음 버튼 누르면 다음 탭으로 이동하도록 구현했습니다.

3. OnboardingVoiceIntroView
- 탭뷰 페이징에 사용 될 두번째 페이지입니다.
- OnboardingVoiceIntroView의 UI를 구현했습니다.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
![Simulator Screen Recording - iPhone 16 - 2025-05-22 at 19 36 45](https://github.com/user-attachments/assets/eac058b1-eb79-459c-a3f9-05de6dae6283)

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->

## Resolved
Resolved: #14 
