### PR TITLE
[FIX] 커스텀 버튼의 터치 영역 문제를 수정했습니다

### DIFF
--- a/KKewo-iOS/KKewo-iOS/Utilities/Components/CustomBorderButton.swift
+++ b/KKewo-iOS/KKewo-iOS/Utilities/Components/CustomBorderButton.swift
@@ -30,10 +30,10 @@ struct CustomBorderButton: View {
             Text(title)
                 .foregroundStyle(titleColor)
                 .font(.pretendard(type: .semibold, size: 18))
+                .frame(maxWidth: .infinity, minHeight: 56)
+                .background(backgroundColor)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
         }
-        .frame(maxWidth: .infinity, minHeight: 56)
-        .background(backgroundColor)
-        .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 }
 


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
1. CustomBorderButton
- 터치 영역 문제를 수정했습니다.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->


```swift
var body: some View {
        Button(action: action) {
            Text(title)
                .foregroundStyle(titleColor)
                .font(.pretendard(type: .semibold, size: 18))
        }
        .frame(maxWidth: .infinity, minHeight: 56)
        .background(backgroundColor)
        .clipShape(RoundedRectangle(cornerRadius: 16))
    }
```
현재 코드에서 Button에 frame, background, clipShape 등을 적용하고 있지만, 이들 뷰 수정자는 실제로는 Button의 내부 콘텐츠(Text)에만 영향을 주고 있을 수 있음을 확인했습니다. 즉, 버튼의 시각적 배경은 넓은데 터치 가능한 영역은 좁게 남아있을 수 있습니다. 

```swift
var body: some View {
        Button(action: action) {
            Text(title)
                .foregroundStyle(titleColor)
                .font(.pretendard(type: .semibold, size: 18))
                .frame(maxWidth: .infinity, minHeight: 56)
                .background(backgroundColor)
                .clipShape(RoundedRectangle(cornerRadius: 16))
        }
    }
```
내부 컨텐츠에 수정자를 래핑해서 수정했습니다.

## Resolved
Resolved: #16 
